### PR TITLE
-replace-format and -orderby support

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var numOfWorkersPtr = flag.Int("c", 2, "the number of concurrent rename workers.
 var trimPrefixPtr = flag.String("trimprefix", "", "trim prefix")
 var trimSuffixPtr = flag.String("trimsuffix", "", "trim suffix")
 var orderBy = flag.String("orderby", "", "order by")
+var seqStart = flag.Int("seqstart", 0, "sequence number start with")
 var sequenceNumber int = 1
 var m sync.Mutex
 
@@ -108,6 +109,7 @@ func main() {
 	}
 
 	if *replacementFormatPtr != "" {
+		sequenceNumber = *seqStart
 		*replacementPtr = ""
 		*fileOnlyPtr = true
 	}
@@ -131,7 +133,6 @@ func main() {
 	}
 
 	var matchRegExp = regexp.MustCompile(*matchPatternPtr)
-
 	var extRegExp *regexp.Regexp = nil
 	if *forExtPtr != "" {
 		extRegExp = regexp.MustCompile("\\." + *forExtPtr + "$")

--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func RenameWorker(cv chan bool, input chan *Entry, output chan *Entry, extRegExp
 
 		entry.newpath = filepath.Join(filepath.Dir(entry.path), newName)
 		if !dryrun {
-			_, err := os.Open(entry.newpath)
+			checkFile, err := os.Open(entry.newpath)
+			defer checkFile.Close()
 			if os.IsNotExist(err) {
 				os.Rename(entry.path, entry.newpath)
 				entry.result = " success"

--- a/orderby.go
+++ b/orderby.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	// "path/filepath"
+	// "os"
+	"sort"
+)
+
+type Files []Entry
+
+func (self Files) Len() int           { return len(self) }
+func (self Files) Less(i, j int) bool { return self[i].newpath < self[j].newpath }
+func (self Files) Swap(i, j int)      { self[i], self[j] = self[j], self[i] }
+
+func (files Files) Sort() { sort.Sort(files) }
+
+type ReverseSort struct{ Files }
+
+func (self ReverseSort) Less(i, j int) bool { return self.Files[i].newpath > self.Files[j].newpath }
+
+type MtimeSort struct{ Files }
+
+func (self MtimeSort) Less(i, j int) bool {
+	return self.Files[i].info.ModTime().UnixNano() < self.Files[j].info.ModTime().UnixNano()
+}
+
+type MtimeReverseSort struct{ Files }
+
+func (self MtimeReverseSort) Less(i, j int) bool {
+	return self.Files[i].info.ModTime().UnixNano() > self.Files[j].info.ModTime().UnixNano()
+}
+
+type SizeSort struct{ Files }
+
+func (self SizeSort) Less(i, j int) bool {
+	return self.Files[i].info.Size() > self.Files[i].info.Size()
+}
+
+type SizeReverseSort struct{ Files }
+
+func (self SizeReverseSort) Less(i, j int) bool {
+	return self.Files[i].info.Size() < self.Files[i].info.Size()
+}

--- a/orderby.go
+++ b/orderby.go
@@ -4,38 +4,38 @@ import (
 	"sort"
 )
 
-type Files []Entry
+type Entries []Entry
 
-func (self Files) Len() int           { return len(self) }
-func (self Files) Less(i, j int) bool { return self[i].newpath < self[j].newpath }
-func (self Files) Swap(i, j int)      { self[i], self[j] = self[j], self[i] }
+func (self Entries) Len() int           { return len(self) }
+func (self Entries) Less(i, j int) bool { return self[i].newpath < self[j].newpath }
+func (self Entries) Swap(i, j int)      { self[i], self[j] = self[j], self[i] }
 
-func (files Files) Sort() { sort.Sort(files) }
+func (files Entries) Sort() { sort.Sort(files) }
 
-type ReverseSort struct{ Files }
+type ReverseSort struct{ Entries }
 
-func (self ReverseSort) Less(i, j int) bool { return self.Files[i].newpath > self.Files[j].newpath }
+func (self ReverseSort) Less(i, j int) bool { return self.Entries[i].newpath > self.Entries[j].newpath }
 
-type MtimeSort struct{ Files }
+type MtimeSort struct{ Entries }
 
 func (self MtimeSort) Less(i, j int) bool {
-	return self.Files[i].info.ModTime().UnixNano() < self.Files[j].info.ModTime().UnixNano()
+	return self.Entries[i].info.ModTime().UnixNano() < self.Entries[j].info.ModTime().UnixNano()
 }
 
-type MtimeReverseSort struct{ Files }
+type MtimeReverseSort struct{ Entries }
 
 func (self MtimeReverseSort) Less(i, j int) bool {
-	return self.Files[i].info.ModTime().UnixNano() > self.Files[j].info.ModTime().UnixNano()
+	return self.Entries[i].info.ModTime().UnixNano() > self.Entries[j].info.ModTime().UnixNano()
 }
 
-type SizeSort struct{ Files }
+type SizeSort struct{ Entries }
 
 func (self SizeSort) Less(i, j int) bool {
-	return self.Files[i].info.Size() > self.Files[i].info.Size()
+	return self.Entries[i].info.Size() > self.Entries[i].info.Size()
 }
 
-type SizeReverseSort struct{ Files }
+type SizeReverseSort struct{ Entries }
 
 func (self SizeReverseSort) Less(i, j int) bool {
-	return self.Files[i].info.Size() < self.Files[i].info.Size()
+	return self.Entries[i].info.Size() < self.Entries[i].info.Size()
 }

--- a/orderby.go
+++ b/orderby.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	// "path/filepath"
-	// "os"
 	"sort"
 )
 


### PR DESCRIPTION
Agenda: 
- To add support for fsrename about sequence number before extension.  
- "-seqnum" to enable sequence number in file name (not extension)
- "-startnum" to define the start number.

Currentimplement:
- Currently it support x.jpg -> x000.jpg

What I have done before this PR:
- multiple "." file name test and verify.
- Over 1000 files test for mutex

BTW: This is my first PR in git :)
